### PR TITLE
Add a `delimiter` option

### DIFF
--- a/lib/DBI/Log.pm
+++ b/lib/DBI/Log.pm
@@ -11,6 +11,7 @@ our %opts = (
     trace => 0,
     timing => 0,
     fh => undef,
+    delimiter => q{},
 );
 
 INIT {
@@ -136,7 +137,7 @@ sub dbilog {
     }
     $query =~ s/^\s*\n|\s*$//g;
     $info = "-- " . scalar(localtime()) . "\n";
-    print {$opts{fh}} "$info$stack$query\n";
+    print {$opts{fh}} "$info$stack$query$opts{delimiter}\n";
     $log->{time1} = time();
     return $log;
 }
@@ -189,6 +190,11 @@ If you want timing information about how long the queries took to
 run add the timing option (on the use line).
 
     use DBI::Log timing => 1;
+
+If you want a delimiter appended to each statement, set the delimiter option
+(on the use line).  The default is to have no delimiter.
+
+    use DBI::Log delimiter => q{;};
 
 The log is formatted as SQL, so if you look at it in an editor, it
 might be highlighted. This is what the output may look like:

--- a/t/delimiter.t
+++ b/t/delimiter.t
@@ -1,0 +1,39 @@
+use strict;
+use warnings;
+use lib "lib";
+use Test::More;
+use DBI;
+use DBI::Log file => "foo2.sql", delimiter;
+
+END {
+    unlink "foo2.db";
+    unlink "foo2.sql";
+};
+
+my $dbh = DBI->connect("dbi:SQLite:dbname=foo2.db", "", "", {RaiseError => 1, PrintError => 0});
+
+my $sth = $dbh->prepare("CREATE TABLE foo2 (a INT, b INT)");
+$sth->execute();
+$dbh->do("INSERT INTO foo2 VALUES (?, ?)", undef, 1, 2);
+$dbh->selectcol_arrayref("SELECT * FROM foo2");
+eval {$dbh->do("INSERT INTO bar VALUES (?, ?)", undef, 1, 2)};
+
+my $output = `cat foo2.sql`;
+like $output, qr/^-- .*
+-- execute .*
+CREATE TABLE foo2 \(a INT, b INT\)
+
+-- .*
+-- do .*
+INSERT INTO foo2 VALUES \('1', '2'\)
+
+-- .*
+-- selectcol_arrayref .*
+SELECT \* FROM foo2
+
+-- .*
+-- do .*
+INSERT INTO bar VALUES \('1', '2'\)
+/, "log output";
+
+done_testing();


### PR DESCRIPTION
...so as to append `;` to each statement, allowing for easier use of the
resulting queries (e.g. to reconstruct the changes).