### PR TITLE
Use Time::HiRes for more useful timings

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -21,6 +21,7 @@ my @requires = (
     "strict" => 0,
     "warnings" => 0,
     "DBI" => 0,
+    "Time::HiRes" => 0,
 );
 
 my @test_requires = (

--- a/lib/DBI/Log.pm
+++ b/lib/DBI/Log.pm
@@ -4,6 +4,7 @@ use 5.006;
 no strict;
 no warnings;
 use DBI;
+use Time::HiRes;
 
 our $VERSION = "0.08";
 our %opts = (
@@ -137,7 +138,7 @@ sub dbilog {
     $query =~ s/^\s*\n|\s*$//g;
     $info = "-- " . scalar(localtime()) . "\n";
     print {$opts{fh}} "$info$stack$query\n";
-    $log->{time1} = time();
+    $log->{time1} = Time::HiRes::time();
     return $log;
 }
 
@@ -145,8 +146,8 @@ sub dbilog2 {
     my ($log) = @_;
     return if $log->{skip};
     if ($opts{timing}) {
-        $log->{time2} = time();
-        my $diff = $log->{time2} - $log->{time1};
+        $log->{time2} = Time::HiRes::time();
+        my $diff = sprintf '%.3f', $log->{time2} - $log->{time1};
         print {$opts{fh}} "-- ${diff}s\n";
     }
     print {$opts{fh}} "\n";


### PR DESCRIPTION
Most queries are showing `0s`; it's much more useful to use Time::HiRes
so even fast queries can show their elapsed time.

Time::HiRes is a core module since perl 5.7.3 so it's not like it's
adding an new external dep.
