### PR TITLE
Handle receiving DBI::st handles and log the query

### DIFF
--- a/lib/DBI/Log.pm
+++ b/lib/DBI/Log.pm
@@ -170,9 +170,11 @@ sub pre_query {
         my $i = 0;
         $query =~ s{\?}{$dbh->quote($args->[$i++])}eg;
     }
-    $query =~ s/^\s*\n|\s*$//g;
+
+    my $query_sql = ref $query eq 'DBI::st' ? $query->{Statement} : $query;
+    $query_sql =~ s/^\s*\n|\s*$//g;
     $info = "-- " . scalar(localtime()) . "\n";
-    print {$opts{fh}} "$info$stack$query\n";
+    print {$opts{fh}} "$info$stack$query_sql\n";
     $log->{time1} = Time::HiRes::time();
     return $log;
 }

--- a/t/test.t
+++ b/t/test.t
@@ -17,6 +17,11 @@ my $sth = $dbh->prepare("CREATE TABLE foo (a INT, b INT)");
 $sth->execute();
 $dbh->do("INSERT INTO foo VALUES (?, ?)", undef, 1, 2);
 $dbh->selectcol_arrayref("SELECT * FROM foo");
+
+# gh#9 - ensure that we handle receiving statement handles and log them
+# appropriately too
+my $sth2 = $dbh->prepare("SELECT * FROM foo");
+$dbh->selectall_arrayref( $sth2, { Slice => {} } );
 eval {$dbh->do("INSERT INTO bar VALUES (?, ?)", undef, 1, 2)};
 
 my $output = `cat foo.sql`;
@@ -30,6 +35,10 @@ INSERT INTO foo VALUES \('1', '2'\)
 
 -- .*
 -- selectcol_arrayref .*
+SELECT \* FROM foo
+
+-- .*
+-- selectall_arrayref .*
 SELECT \* FROM foo
 
 -- .*


### PR DESCRIPTION
Some DBI methods wrapped - e.g. `selectall_arrayref` for instance - can
be given a pre-prepared statement handle or SQL.

Handle the case where $query is a pre-prepared statement handle and
extract the query from it, rather than accidentally logging the handle
ref as e.g. `DBI::st=HASH(0xdeadbeef)`.

Fixes #9
