### PR TITLE
Add JSON output format support

### DIFF
--- a/lib/DBI/Log.pm
+++ b/lib/DBI/Log.pm
@@ -14,6 +14,7 @@ our %opts = (
     replace_placeholders => 1,
     fh => undef,
     exclude => undef,
+    format => 'sql',
 );
 
 my $orig_execute = \&DBI::st::execute;
@@ -105,6 +106,12 @@ sub import {
         }
         open $opts{fh}, ">>", $file2 or die "Can't open $opts{file}: $!";
     }
+
+    # Load JSON, if we're asked for JSON output
+    if ($opts{format} eq 'json') {
+        eval "require JSON;"
+            or die "Can't produce JSON output without JSON CPAN module!";
+    } 
 }
 
 sub pre_query {
@@ -158,13 +165,17 @@ sub pre_query {
         @filtered_callers = ($filtered_callers[-1]);
     }
 
-    my $stack = "";
+    my @stack;
     for my $caller (@filtered_callers) {
         my ($package, $file, $line, $sub) = @$caller;
         my $short_sub = $sub;
         $short_sub =~ s/.*:://;
         $short_sub = $name if $sub =~ /^DBI::Log::__ANON__/;
-        $stack .= "-- $short_sub $file $line\n";
+        push @stack, {
+            sub => $short_sub,
+            file => $file,
+            line => $line,
+        };
     }
 
     if (ref($query) && ref($query) eq "DBI::st") {
@@ -196,9 +207,20 @@ sub pre_query {
     }
 
     $query =~ s/^\s*\n|\s*$//g;
-    $info = "-- " . scalar(localtime()) . "\n";
-    print {$opts{fh}} "$info$stack$query\n";
-    $log->{time1} = Time::HiRes::time();
+    $log->{time_started} = Time::HiRes::time();
+    if ($opts{format} eq 'sql') {
+        $info = "-- " . scalar(localtime()) . "\n";
+        my $stack_txt = join "", map { 
+            "-- $_->{sub} $_->{file} $_->{line}\n" 
+        } @stack;
+        print {$opts{fh}} "$info$stack_txt$query\n";
+    } else {
+        # For JSON output we don't want to output anything yet,
+        # so post_query() can emit the whole JSON object, just remember
+        # them
+        $log->{query} = $query;
+        $log->{stack} = \@stack;
+    }
     return $log;
 }
 
@@ -206,11 +228,24 @@ sub post_query {
     my ($log) = @_;
     return if $log->{skip};
     if ($opts{timing}) {
-        $log->{time2} = Time::HiRes::time();
-        my $diff = sprintf '%.3f', $log->{time2} - $log->{time1};
-        print {$opts{fh}} "-- ${diff}s\n";
+        $log->{time_ended} = Time::HiRes::time();
+        $log->{time_taken} = sprintf '%.3f', 
+            $log->{time_ended} - $log->{time_started};
     }
-    print {$opts{fh}} "\n";
+   
+    if ($opts{format} eq 'sql') {
+        # For SQL output format, pre_query already printed most of
+        # the info, we just need to add the time taken - and that only
+        # if we're doing timings...
+        if ($opts{timing}) {
+            print {$opts{fh}} "-- $log->{time_taken}s\n";
+        }
+        print {$opts{fh}} "\n";
+    } elsif ($opts{format} eq 'json') {
+        # print all the info as JSON
+        print {$opts{fh}} JSON::to_json($log) . "\n";
+    }
+
 }
 
 1;
@@ -275,6 +310,23 @@ highlighted. This is what the output may look like:
     -- do t/test.t 27
     -- (eval) t/test.t 27
     INSERT INTO bar VALUES ('1', '2')
+
+The default format, as illustrated above, is the SQL queries, with information
+added as SQL comments - so you can have a .sql file you could pass to your
+DB to re-run those queries, etc.
+
+JSON output is also available, enable it by setting the C<format> option
+to C<json> e.g.:
+
+    use DBI::Log format => 'json';
+
+Query logs will then be emitted in "line-delimited JSON" format, where each
+"record" is a JSON object, separated by newlines - this format is understood
+by many tools such as C<jq>, ElasticSearch's C<logstash> etc, and is useful
+if you want to post-process the information - for example, using jq to
+get only queries which took longer than a second:
+
+    jq 'select(.time_taken >= 1)' < querylog.json
 
 There is a built-in way to log with DBI, which can be enabled with
 DBI->trace(1), but the output is not easy to read through.

--- a/t/test.t
+++ b/t/test.t
@@ -8,10 +8,12 @@ use DBI::Log file => "foo.sql";
 
 my $log_file = "foo.sql";
 my $db_file = "foo.db";
+my $json_file = "foo.json";
 
 END {
     unlink $log_file;
     unlink $db_file;
+    unlink $json_file;
 };
 
 my $dbh = DBI->connect("dbi:SQLite:dbname=$db_file", "", "", {RaiseError => 1, PrintError => 0});
@@ -53,6 +55,28 @@ check("do dies still logs", qr{^-- .*
 -- do .*
 INSERT INTO bar VALUES \('1', '2'\)
 });
+
+
+# Now, test JSON output - only if JSON.pm is available
+SKIP: {
+    skip "Need JSON.pm to test JSON output", 2 unless eval "require JSON";
+
+    # Manual re-import to change settings
+    DBI::Log->import(file => $json_file, format => "json");
+    #   Failed test 'JSON log logged the query'
+
+    my $json_test_query = "INSERT INTO foo VALUES (3, 4)";
+    $dbh->do($json_test_query);
+
+    my $hopefully_json = `cat $json_file`; # todo - slurp instead of shelling out
+    my $json;
+    eval { $json = JSON::decode_json($hopefully_json); };
+    ok($json, "Decoded JSON log to something truthy");
+    is ($json->{query}, $json_test_query, "JSON log logged the query");
+    diag "JSON: ", $hopefully_json;
+}
+
+
 
 done_testing();
 


### PR DESCRIPTION
Enable JSON output with new `format => "json"` option - very useful if you want to be able to parse the logs afterwards for analysis - e.g. filtering out only the slowest queries, or sorting by time taken, orextracting just the queries, or filtering queries to only those from
the package(s) you're interested in, or... whatever reason you need to post-process it, but having the logs in a structured parseable format really helps - from dead simple queries like this:

```
jq 'select(.time_taken >= 1)' < querylog.json
```
... to much more complicated things.

Outputs a JSON object for each query, line-separated - the "[line-delimited JSON](https://jsonlines.org/)" format, understood by many tools such as `jq`, ElasticSearch's `logstash` and plenty of others.

_Doesn't_ add JSON as a hard dependency - will die on import if you set `format => "json"` but don't have the JSON CPAN module installed, and the tests for JSON format logging skip if if's not installed too.
