### PR TITLE
Set autoflush on output filehandle

### DIFF
--- a/lib/DBI/Log.pm
+++ b/lib/DBI/Log.pm
@@ -4,6 +4,7 @@ use 5.006;
 no strict;
 no warnings;
 use DBI;
+use IO::Handle;
 use Time::HiRes;
 
 our $VERSION = "0.11";
@@ -105,6 +106,9 @@ sub import {
             $file2 =~ s{^~/}{$home/};
         }
         open $opts{fh}, ">>", $file2 or die "Can't open $opts{file}: $!\n";
+        # autoflush so that tailing to watch queries being performed works
+        # as you'd expect
+        $opts{fh}->autoflush(1);
     }
 }
 


### PR DESCRIPTION
If we're outputting to a file, set autoflush on the handle, so that each query we log ends up in the file right away; otherwise, with the default block-buffered output, the query might not appear in the log until some time later, which can be confusing.

It's possible that this could carry a mild performance penalty, but, if you're logging all DB queries to a file, hopefully you're doing that temporarily in a dev environment, not in production!