### PR TITLE
Fix hand-rolled JSON generation (escape quotes etc)

### DIFF
--- a/lib/DBI/Log.pm
+++ b/lib/DBI/Log.pm
@@ -291,7 +291,11 @@ sub to_json {
         $out = $val;
     }
     else {
-        $val =~ s/"/\"/g;
+        # Make the value suitable to use in a JSON string - no newlines, escape
+        # # control characters and double quotes.
+        $val =~ s/"/\\"/g;
+        $val =~ s/\n/ /g;
+        $val =~ s/([\x00-\x1F])/sprintf("\\u%04x", ord($1))/eg;
         $out = "\"$val\"";
     }
 


### PR DESCRIPTION
The hand-rolled JSON generation could generate invalid JSON in some cases - if JSON strings contained double quotes, they need to be escaped, newlines need to be removed/escaped with it being line-delimited JSON format, and control characters need to be escaped.