### PR TITLE
Fix selectall_hashref logging

### DIFF
--- a/lib/DBI/Log.pm
+++ b/lib/DBI/Log.pm
@@ -47,9 +47,9 @@ my $orig_selectcol_arrayref = \&DBI::db::selectcol_arrayref;
 
 my $orig_selectall_hashref = \&DBI::db::selectall_hashref;
 *DBI::db::selectall_hashref = sub {
-    my ($dbh, $query, $yup, @args) = @_;
+    my ($dbh, $query, $key, $yup, @args) = @_;
     my $log = pre_query("selectall_hashref", $dbh, undef, $query, \@args);
-    my $retval = $orig_selectall_hashref->($dbh, $query, $yup, @args);
+    my $retval = $orig_selectall_hashref->($dbh, $query, $key, $yup, @args);
     post_query($log);
     return $retval;
 };


### PR DESCRIPTION
The logging output for selectall_hashref includes `\%attr` as if it were one of the query parameters. This is because the logging wrapper is missing one of the method parameters.

Fixes https://rt.cpan.org/Ticket/Display.html?id=155192.