### PR TITLE
re-enable strict and (some) warnings

### DIFF
--- a/lib/DBI/Log.pm
+++ b/lib/DBI/Log.pm
@@ -2,10 +2,12 @@ package DBI::Log;
 
 use 5.006;
 no strict;
-no warnings;
+use warnings;
 use DBI;
 use IO::Handle;
 use Time::HiRes;
+
+no warnings 'redefine';
 
 our $VERSION = "0.12";
 our %opts = (

--- a/lib/DBI/Log.pm
+++ b/lib/DBI/Log.pm
@@ -11,7 +11,7 @@ no warnings 'redefine';
 
 our $VERSION = "0.12";
 our %opts = (
-    file => $file,
+    file => undef,
     trace => 0,
     timing => 0,
     replace_placeholders => 1,
@@ -59,7 +59,7 @@ my $orig_selectall_hashref = \&DBI::db::selectall_hashref;
 my $orig_selectrow_arrayref = \&DBI::db::selectrow_arrayref;
 *DBI::db::selectrow_arrayref = sub {
     my ($dbh, $query, $yup, @args) = @_;
-    my $log = pre_query("selectrow_arrayref", $dbh, $sth, $query, \@args);
+    my $log = pre_query("selectrow_arrayref", $dbh, undef, $query, \@args);
     my $retval = $orig_selectrow_arrayref->($dbh, $query, $yup, @args);
     post_query($log);
     return $retval;

--- a/lib/DBI/Log.pm
+++ b/lib/DBI/Log.pm
@@ -1,7 +1,7 @@
 package DBI::Log;
 
 use 5.006;
-no strict;
+use strict;
 use warnings;
 use DBI;
 use IO::Handle;


### PR DESCRIPTION
no need to turn off strict and warnings globally.

turning on strict revealed two unintended global variables, which I removed. 
I turned off only the warnings which were expected.
