### PR TITLE
Add uninstall function to unwrap DBI functions

### DIFF
--- a/lib/DBI/Log.pm
+++ b/lib/DBI/Log.pm
@@ -2,10 +2,12 @@ package DBI::Log;
 
 use 5.006;
 no strict;
-no warnings;
+use warnings;
 use DBI;
 use IO::Handle;
 use Time::HiRes;
+
+no warnings 'redefine';
 
 our $VERSION = "0.12";
 our %opts = (

--- a/lib/DBI/Log.pm
+++ b/lib/DBI/Log.pm
@@ -7,8 +7,6 @@ use DBI;
 use IO::Handle;
 use Time::HiRes;
 
-no warnings 'redefine';
-
 our $VERSION = "0.12";
 our %opts = (
     file => undef,
@@ -20,78 +18,99 @@ our %opts = (
     format => "sql",
 );
 
-my $orig_execute = \&DBI::st::execute;
-*DBI::st::execute = sub {
-    my ($sth, @args) = @_;
-    my $log = pre_query("execute", $sth->{Database}, $sth, $sth->{Statement}, \@args);
-    my $retval = $orig_execute->($sth, @args);
-    post_query($log);
-    return $retval;
-};
+my %orig;
 
-my $orig_selectall_arrayref = \&DBI::db::selectall_arrayref;
-*DBI::db::selectall_arrayref = sub {
-    my ($dbh, $query, $yup, @args) = @_;
-    my $log = pre_query("selectall_arrayref", $dbh, undef, $query, \@args);
-    my $retval = $orig_selectall_arrayref->($dbh, $query, $yup, @args);
-    post_query($log);
-    return $retval;
-};
+sub is_installed {
+    return keys %orig ? 1 : 0;
+}
 
-my $orig_selectcol_arrayref = \&DBI::db::selectcol_arrayref;
-*DBI::db::selectcol_arrayref = sub {
-    my ($dbh, $query, $yup, @args) = @_;
-    my $log = pre_query("selectcol_arrayref", $dbh, undef, $query, \@args);
-    my $retval = $orig_selectcol_arrayref->($dbh, $query, $yup, @args);
-    post_query($log);
-    return $retval;
-};
+sub install {
+    return if is_installed();
+    $orig{execute} = \&DBI::st::execute;
+    $orig{selectall_arrayref} = \&DBI::db::selectall_arrayref;
+    $orig{selectcol_arrayref} = \&DBI::db::selectcol_arrayref;
+    $orig{selectall_hashref} = \&DBI::db::selectall_hashref;
+    $orig{selectrow_arrayref} = \&DBI::db::selectrow_arrayref;
+    $orig{selectrow_array} = \&DBI::db::selectrow_array;
+    $orig{selectrow_hashref} = \&DBI::db::selectrow_hashref;
+    $orig{do} = \&DBI::db::do;
 
-my $orig_selectall_hashref = \&DBI::db::selectall_hashref;
-*DBI::db::selectall_hashref = sub {
-    my ($dbh, $query, $key, $yup, @args) = @_;
-    my $log = pre_query("selectall_hashref", $dbh, undef, $query, \@args);
-    my $retval = $orig_selectall_hashref->($dbh, $query, $key, $yup, @args);
-    post_query($log);
-    return $retval;
-};
+    no warnings 'redefine';
 
-my $orig_selectrow_arrayref = \&DBI::db::selectrow_arrayref;
-*DBI::db::selectrow_arrayref = sub {
-    my ($dbh, $query, $yup, @args) = @_;
-    my $log = pre_query("selectrow_arrayref", $dbh, undef, $query, \@args);
-    my $retval = $orig_selectrow_arrayref->($dbh, $query, $yup, @args);
-    post_query($log);
-    return $retval;
-};
+    *DBI::st::execute = sub {
+        my ($sth, @args) = @_;
+        my $log = pre_query("execute", $sth->{Database}, $sth, $sth->{Statement}, \@args);
+        my $retval = $orig{execute}->($sth, @args);
+        post_query($log);
+        return $retval;
+    };
 
-my $orig_selectrow_array = \&DBI::db::selectrow_array;
-*DBI::db::selectrow_array = sub {
-    my ($dbh, $query, $yup, @args) = @_;
-    my $log = pre_query("selectrow_array", $dbh, undef, $query, \@args);
-    my $retval = $orig_selectrow_array->($dbh, $query, $yup, @args);
-    post_query($log);
-    return $retval;
-};
+    *DBI::db::selectall_arrayref = sub {
+        my ($dbh, $query, $yup, @args) = @_;
+        my $log = pre_query("selectall_arrayref", $dbh, undef, $query, \@args);
+        my $retval = $orig{selectall_arrayref}->($dbh, $query, $yup, @args);
+        post_query($log);
+        return $retval;
+    };
 
-my $orig_selectrow_hashref = \&DBI::db::selectrow_hashref;
-*DBI::db::selectrow_hashref = sub {
-    my ($dbh, $query, $yup, @args) = @_;
-    my $log = pre_query("selectrow_hashref", $dbh, undef, $query, \@args);
-    my $retval = $orig_selectrow_hashref->($dbh, $query, $yup, @args);
-    post_query($log);
-    return $retval;
-};
+    *DBI::db::selectcol_arrayref = sub {
+        my ($dbh, $query, $yup, @args) = @_;
+        my $log = pre_query("selectcol_arrayref", $dbh, undef, $query, \@args);
+        my $retval = $orig{selectcol_arrayref}->($dbh, $query, $yup, @args);
+        post_query($log);
+        return $retval;
+    };
 
-my $orig_do = \&DBI::db::do;
-*DBI::db::do = sub {
-    my ($dbh, $query, $yup, @args) = @_;
-    my $log = pre_query("do", $dbh, undef, $query, \@args);
-    my $retval = $orig_do->($dbh, $query, $yup, @args);
-    post_query($log);
-    return $retval;
-};
+    *DBI::db::selectall_hashref = sub {
+        my ($dbh, $query, $key, $yup, @args) = @_;
+        my $log = pre_query("selectall_hashref", $dbh, undef, $query, \@args);
+        my $retval = $orig{selectall_hashref}->($dbh, $query, $key, $yup, @args);
+        post_query($log);
+        return $retval;
+    };
 
+    *DBI::db::selectrow_arrayref = sub {
+        my ($dbh, $query, $yup, @args) = @_;
+        my $log = pre_query("selectrow_arrayref", $dbh, undef, $query, \@args);
+        my $retval = $orig{selectrow_arrayref}->($dbh, $query, $yup, @args);
+        post_query($log);
+        return $retval;
+    };
+
+    *DBI::db::selectrow_array = sub {
+        my ($dbh, $query, $yup, @args) = @_;
+        my $log = pre_query("selectrow_array", $dbh, undef, $query, \@args);
+        my $retval = $orig{selectrow_array}->($dbh, $query, $yup, @args);
+        post_query($log);
+        return $retval;
+    };
+
+    *DBI::db::selectrow_hashref = sub {
+        my ($dbh, $query, $yup, @args) = @_;
+        my $log = pre_query("selectrow_hashref", $dbh, undef, $query, \@args);
+        my $retval = $orig{selectrow_hashref}->($dbh, $query, $yup, @args);
+        post_query($log);
+        return $retval;
+    };
+
+    *DBI::db::do = sub {
+        my ($dbh, $query, $yup, @args) = @_;
+        my $log = pre_query("do", $dbh, undef, $query, \@args);
+        my $retval = $orig{do}->($dbh, $query, $yup, @args);
+        post_query($log);
+        return $retval;
+    };
+}
+
+sub uninstall {
+    return unless is_installed();
+    no strict 'refs';
+    no warnings 'redefine';
+    foreach my $key (keys %orig) {
+        *{"DBI::db::$key"} = delete $orig{$key};
+    }
+    return;
+}
 
 sub import {
     my ($package, %args) = @_;
@@ -303,6 +322,8 @@ sub to_json {
 
     return $out;
 }
+
+install();
 
 1;
 

--- a/lib/DBI/Log.pm
+++ b/lib/DBI/Log.pm
@@ -454,6 +454,31 @@ look alike without the values.
 
 =back
 
+=head1 FUNCTIONS
+
+No functions are exported, nor are they needed in default operational mode.
+
+=over 4
+
+=item C<uninstall>
+
+The C<DBI::Log> module works by wrapping DBI's core functions C<do>, C<execute>,
+C<selectall_arrayref>, C<selectrow_hashref>, et al., with code that 
+inspects/copies the parameters and writes log messages using them.
+
+The C<uninstall> function removes the wrappers to DBI's core functions, 
+restoring the original code to the original symbols.  Naturally, this
+stops the logging.  
+
+You can use the C<install> function to re-enable the logging later.
+
+=item C<is_installed>
+
+This function returns true if the DBI functions are wrapped (logging is 
+enabled), false otherwise.
+
+=back
+
 =head1 SEE ALSO
 
 There is a built-in way to log with DBI, which can be enabled with

--- a/lib/DBI/Log.pm
+++ b/lib/DBI/Log.pm
@@ -11,7 +11,7 @@ no warnings 'redefine';
 
 our $VERSION = "0.12";
 our %opts = (
-    file => $file,
+    file => undef,
     trace => 0,
     timing => 0,
     replace_placeholders => 1,
@@ -59,7 +59,7 @@ my $orig_selectall_hashref = \&DBI::db::selectall_hashref;
 my $orig_selectrow_arrayref = \&DBI::db::selectrow_arrayref;
 *DBI::db::selectrow_arrayref = sub {
     my ($dbh, $query, $yup, @args) = @_;
-    my $log = pre_query("selectrow_arrayref", $dbh, $sth, $query, \@args);
+    my $log = pre_query("selectrow_arrayref", $dbh, undef, $query, \@args);
     my $retval = $orig_selectrow_arrayref->($dbh, $query, $yup, @args);
     post_query($log);
     return $retval;

--- a/lib/DBI/Log.pm
+++ b/lib/DBI/Log.pm
@@ -1,7 +1,7 @@
 package DBI::Log;
 
 use 5.006;
-no strict;
+use strict;
 use warnings;
 use DBI;
 use IO::Handle;

--- a/t/test.t
+++ b/t/test.t
@@ -16,6 +16,8 @@ END {
     unlink $json_file;
 };
 
+is(DBI::Log::is_installed(), 1, 'DBI::Log::is_installed is true');
+
 my $dbh = DBI->connect("dbi:SQLite:dbname=$db_file", "", "", {RaiseError => 1, PrintError => 0});
 
 my $sth = $dbh->prepare("CREATE TABLE foo (a INT, b INT)");
@@ -65,6 +67,17 @@ $dbh->do($query);
 
 my $output = `cat $json_file`;
 like $output, qr/^\{"query": "INSERT INTO foo VALUES \(3, 4\)"/, "JSON format";
+
+
+DBI::Log::uninstall();
+
+is(DBI::Log::is_installed(), 0, 'after uninstall DBI::Log::is_installed now false');
+
+$query = 'INSERT INTO foo VALUES (13, 31)';
+$dbh->do($query);
+$output = `cat $json_file`;
+unlike $output, qr/13, 31/, "and logging stopped";
+
 
 done_testing();
 


### PR DESCRIPTION
This branch is based on the `minor-fixes` branch (and so includes those 3 commits).
I put that one up separately in PR #21  so it can be merged more quickly, and in case you have discussion about these larger changes.

Moved the installation of the DBI overrides into a function.
Added an `uninstall` function to remove the overrides (and restore DBI's original code).
Added a `is_installed` function to tell whether the wrappers are in place.
Added POD and tests of the above.

Always good to isolate the no strict and no warnings scopes to a minimum.